### PR TITLE
Fix names to be able to use local credstore for sensitive data storage.

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -1,4 +1,4 @@
-[hashicorp_vault]
+[hashicorp-vault]
 # The address or hostname of the Hashicorp Vault.
 ; address=<address>
 
@@ -6,7 +6,7 @@
 # Default is 8200.
 ; port=8200
 
-[hashicorp_vault_approle_authentication]
+[approle-authentication]
 # Name of role for AppRole authentication.
 # Make sure the role has a policy set to have permission to
 # read the endpoint set in secrets_path.
@@ -18,7 +18,7 @@
 # can use the root token, but it is ill advised to do so.
 ; vault_token=<token>
 
-[hashicorp_vault_secrets_engine_kv_v1]
+[engine-kv-v1]
 # Path of endpoint where the users and passwords are stored
 # as secrets (key: username, value: password).
 # e.g. secrets/users
@@ -57,7 +57,7 @@
 # 'debug', 'info', 'warning', 'error', 'critical'
 ; log_level=info
 
-[https_proxy]
+[https-proxy]
 # To set the HTTPS proxy environment for the plugin, configure the following.
 ; server=<proxy-server-name-or-ip>
 ; port=3128

--- a/lib/client.py
+++ b/lib/client.py
@@ -59,16 +59,16 @@ class ClientFactory:
     def from_config(cls, config):
         requests_tls = RequestsTLS.from_config(config)
         vault_url = '{}://{}:{}'.format('https' if requests_tls.tls_enabled else 'http',
-                                        config.get('hashicorp_vault', 'address', required=True),
-                                        config.getint('hashicorp_vault', 'port', default=8200))
-        role = config.get('hashicorp_vault_approle_authentication', 'role')
+                                        config.get('hashicorp-vault', 'address', required=True),
+                                        config.getint('hashicorp-vault', 'port', default=8200))
+        role = config.get('approle-authentication', 'role')
         if role:
-            vault_token = config.get('hashicorp_vault_approle_authentication', 'vault_token')
+            vault_token = config.get('approle-authentication', 'vault_token')
             authenticator = AppRoleAuthenticator(vault_url, vault_token, role)
         else:
             raise VaultException('No valid auth method can be determined based on config')
 
-        secrets_path = config.get('hashicorp_vault_secrets_engine_kv_v1', 'secrets_path')
+        secrets_path = config.get('engine-kv-v1', 'secrets_path')
         if secrets_path:
             secret_retriever = KVEngineV1SecretRetriever(vault_url, secrets_path)
         else:

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -71,15 +71,15 @@ def hc_wrong_account(site_parameters):
 @pytest.fixture
 def hc_config_engine_kv_v1(site_parameters):
     yield dedent("""
-        [hashicorp_vault]
+        [hashicorp-vault]
         address = {address}
         port = {port}
 
-        [hashicorp_vault_approle_authentication]
+        [approle-authentication]
         role = {role}
         vault_token = {vault_token}
 
-        [hashicorp_vault_secrets_engine_kv_v1]
+        [engine-kv-v1]
         secrets_path = {secrets_path}
     """.format(
         address=site_parameters['address'],

--- a/lib/tests/test_client.py
+++ b/lib/tests/test_client.py
@@ -53,19 +53,19 @@ LOGIN_ENDPOINT = URL + '/v1/auth/approle/login'
 SECRETS_ENDPOINT = URL + '/v1/' + SECRETS_PATH
 
 HASHICORP_VAULT_CONFIG = dedent('''
-    [hashicorp_vault]
+    [hashicorp-vault]
     address = {}
     port = {}
 '''.format(ADDRESS, PORT))
 
 HASHICORP_VAULT_APPROLE_AUTH_CONFIG = dedent('''
-    [hashicorp_vault_approle_authentication]
+    [approle-authentication]
     role = {}
     vault_token = {}
 '''.format(ROLE, VAULT_TOKEN))
 
 HASHICORP_VAULT_KV_V1_CONFIG = dedent('''
-    [hashicorp_vault_secrets_engine_kv_v1]
+    [engine-kv-v1]
     secrets_path = {}
 '''.format(SECRETS_PATH))
 

--- a/lib/tests/test_plugin.py
+++ b/lib/tests/test_plugin.py
@@ -31,15 +31,15 @@ from ..plugin import Plugin
 @fixture
 def configured_plugin():
     config = dedent('''
-        [hashicorp_vault]
+        [hashicorp-vault]
         address = test.vault
         port = 8200
 
-        [hashicorp_vault_approle_authentication]
+        [approle-authentication]
         role = testrole
         vault_token = test_token
 
-        [hashicorp_vault_secrets_engine_kv_v1]
+        [engine-kv-v1]
         secrets_path = kv/users
     ''')
     return Plugin(config)


### PR DESCRIPTION
Naming must be internet hostname compatible and also fit in current UI
width preferably.
