### PR TITLE
Rewrite defult.cfg based on input from doc team and fix version.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.1.1 2019-10-07
+
+INCLUDES INCOMPATIBLE CONFIG CHANGE!
+Rewrite default.cfg to be more logical and also according to documentation guidelines.
+Move password_field, key_field, delimiter under secret-kv-v1 to be more readable.
+
 1.1.0 2019-10-02
 
 Add LDAP and userpass authentication methods.

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,5 +2,5 @@ api: 1.3
 type: credentialstore
 name: SPS_hashicorp
 description: One Identity Safeguard for Privileged Hashicorp Vault plugin
-version: 1.0.0
+version: 1.1.1
 entry_point: main.py

--- a/default.cfg
+++ b/default.cfg
@@ -1,51 +1,71 @@
 [hashicorp]
-# The address or hostname of the Hashicorp Vault.
-# A list of address can be configured separated by ','
+# The address or hostname of the Hashicorp Vault. Separate more than one
+# addresses with a comma (,).
 ; address=<address>
 
-# Port of the Hashicorp Vault.
-# Default is 8200.
+# The port number of the Hashicorp Vault. Default is 8200.
 ; port=8200
 
-# The authentication method to use to connect
-# to the vault.
-# Values can be ldap, userpass
+# The authentication method to use to connect to the Hashicorp Vault. The value
+# can be one of the following: ldap or userpass.
 ; authentication_method=<authentication_method>
 
-# Defines which credentials to use
-# Possible values are: explicit or gateway
-# In case of explicit the username and password need to be configured
-# Default is gateway
+# The credential type to use. The value can be one of the following: explicit or
+# gateway. If you use credential type, you must also configure the username and
+# password parameters. Default is gateway.
 ; use_credential=gateway
 
-# The username used to authenticate with
+# The username used to authenticate to the Hashicorp Vault in case you have configured
+# the use_credential parameter as explicit
 ; username=<username>
 
-# Delimiter character to use for parsing secret field from user defined secret path
-# E.g. if delimiter is ":" then user may type kv/secret:password and the path shall
-# be kv/secret and the field name shall be password.
-# Delimiter can be redefined on the fly by the user by starting the path with a single
-# character element. E.g. /;/kv/secret;password
-; delimiter=
-
-# The password used to authenticate with
+# The password used to authenticate to the Hashicorp Vault in case you have configured
+# the use_credential parameter as explicit.
 ; password=<password>
 
-# From which value field to retrieve the password secret from, unless user defined.
-# Default is password
-;password_field=password
-
-# From which value field to retrieve the SSH private key secret from, unless user
-# defined. Default is key
-;key_field=key
-
 [engine-kv-v1]
-# Path of endpoint where the users and passwords are stored as secrets (key: username,
-# field: password/key). This can be overruled by asking the user and filling the "vp"
-# key in an AA plugin in the same connection policy. See [question_1] parameter
-# in any official AA plugin tutorial.
-# e.g. secrets/users
+# The path of the endpoint under which the user names and passwords are stored as secrets.
+# For example, secrets/users. The server username is then appended to the path on-the-fly.
+# This compound path points to an object that has the password or key as one of its fields.
 ; secrets_path=<path>
+
+# The value field to retrieve the password secret from, unless user-defined.
+# This parameter is not related to the password parameter.
+# Default is password
+; password_field=password
+
+# The value field to retrieve the SSH private key secret from, unless user-defined.
+# Default is key
+; key_field=key
+
+# The character to use as delimiter so that SPS can parse the secret field from
+# the user-defined compound path. For example, if the value of the delimiter parameter
+# is :, then you can enter the value of the compound path as kv/secret:mypassword.
+# The path will then be parsed as kv/secret and the value of password_field name will
+# be parsed as mypassword.
+; delimiter=<delimiter>
+
+[tls]
+# To disable TLS completely, enter no as the value of this parameter.
+# Default is yes
+; enabled = yes
+
+# Configure this parameter to enable client-side verification. The certificate shown
+# by the server will be checked with this CA.
+# If the value of this parameter is $[<trusted_ca_list_name>], the certificates are
+# retrieved from the trusted CA list configured on SPS, identified by the name.
+# When the certificate is inserted into the configuration file, it must be in PEM
+# format and all the new lines must be indented with one whitespace. If it is a chain,
+# insert the certificates right after each other.
+; ca_cert = <ca-certificate-chain>
+; ca_cert = $[<trusted_ca_list_name>]
+
+# Configure this parameter to enable server-side verification. If the value of this
+# parameter is $, the certificate identified by the section and option pair is retrieved
+# from the configured Credential Store. When the certificate is inserted into the
+# configuration file, it must be in PEM format and all the new lines must be indented
+# with one whitespace. Note that encrypted keys are not supported.
+; client_cert = <client-certificate-and-key>
 
 ###### Common plugin options ######
 # To enable or change a parameter, uncomment its line by removing the ';'
@@ -83,12 +103,3 @@
 # To set the HTTPS proxy environment for the plugin, configure the following.
 ; server=<proxy-server-name-or-ip>
 ; port=3128
-
-[check-in-trigger]
-# The check-in-trigger selects when the credentials are checked in. The choices
-# are 'session-ended' or 'authentication-completed'. The 'default' parameter
-# applies to all protocols, but may be overruled per protocol.
-; default=session-ended
-; rdp=session-ended
-; ssh=session-ended
-; telnet=session-ended

--- a/default.cfg.plugin
+++ b/default.cfg.plugin
@@ -1,39 +1,68 @@
 [hashicorp]
-# The address or hostname of the Hashicorp Vault.
-# A list of address can be configured separated by ','
+# The address or hostname of the Hashicorp Vault. Separate more than one
+# addresses with a comma (,).
 ; address=<address>
 
-# Port of the Hashicorp Vault.
-# Default is 8200.
+# The port number of the Hashicorp Vault. Default is 8200.
 ; port=8200
 
-# The authentication method to use to connect
-# to the vault.
-# Values can be ldap, userpass
+# The authentication method to use to connect to the Hashicorp Vault. The value
+# can be one of the following: ldap or userpass.
 ; authentication_method=<authentication_method>
 
-# Defines which credentials to use
-# Possible values are: expilict or gateway
-# In case of explicit the username and password need to be configured
-# Default is gateway
+# The credential type to use. The value can be one of the following: explicit or
+# gateway. If you use credential type, you must also configure the username and
+# password parameters. Default is gateway.
 ; use_credential=gateway
 
-# The username used to authenticate with
+# The username used to authenticate to the Hashicorp Vault in case you have configured
+# the use_credential parameter as explicit
 ; username=<username>
 
-# The password used to authenticate with
+# The password used to authenticate to the Hashicorp Vault in case you have configured
+# the use_credential parameter as explicit.
 ; password=<password>
 
-# From which value field to retrieve the password secret from
-# Default is password
-;password_field=password
-
-# From which value field to retrieve the SSH private key secret from
-# Default is key
-;key_field=key
-
 [engine-kv-v1]
-# Path of endpoint where the users and passwords are stored
-# as secrets (key: username, value: password).
-# e.g. secrets/users
+# The path of the endpoint under which the user names and passwords are stored as secrets.
+# For example, secrets/users. The server username is then appended to the path on-the-fly.
+# This compound path points to an object that has the password or key as one of its fields.
 ; secrets_path=<path>
+
+# The value field to retrieve the password secret from, unless user-defined.
+# This parameter is not related to the password parameter.
+# Default is password
+; password_field=password
+
+# The value field to retrieve the SSH private key secret from, unless user-defined.
+# Default is key
+; key_field=key
+
+# The character to use as delimiter so that SPS can parse the secret field from
+# the user-defined compound path. For example, if the value of the delimiter parameter
+# is :, then you can enter the value of the compound path as kv/secret:mypassword.
+# The path will then be parsed as kv/secret and the value of password_field name will
+# be parsed as mypassword.
+; delimiter=<delimiter>
+
+[tls]
+# To disable TLS completely, enter no as the value of this parameter.
+# Default is yes
+; enabled = yes
+
+# Configure this parameter to enable client-side verification. The certificate shown
+# by the server will be checked with this CA.
+# If the value of this parameter is $[<trusted_ca_list_name>], the certificates are
+# retrieved from the trusted CA list configured on SPS, identified by the name.
+# When the certificate is inserted into the configuration file, it must be in PEM
+# format and all the new lines must be indented with one whitespace. If it is a chain,
+# insert the certificates right after each other.
+; ca_cert = <ca-certificate-chain>
+; ca_cert = $[<trusted_ca_list_name>]
+
+# Configure this parameter to enable server-side verification. If the value of this
+# parameter is $, the certificate identified by the section and option pair is retrieved
+# from the configured Credential Store. When the certificate is inserted into the
+# configuration file, it must be in PEM format and all the new lines must be indented
+# with one whitespace. Note that encrypted keys are not supported.
+; client_cert = <client-certificate-and-key>

--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -84,7 +84,7 @@ class Plugin(CredentialStorePlugin):
 
     def secret_path_and_field(self, account, asset, secret_type, user_defined_path):
         default_field = self.plugin_configuration.get(
-            'hashicorp',
+            'engine-kv-v1',
             self.SECRET_TYPE_TO_FIELD[secret_type]["option"],
             default=self.SECRET_TYPE_TO_FIELD[secret_type]["default"]
         )
@@ -104,7 +104,7 @@ class Plugin(CredentialStorePlugin):
 
     def parse_user_defined_path_and_field(self, path, default_field):
         field = default_field
-        delimiter = self.plugin_configuration.get('hashicorp', 'delimiter')
+        delimiter = self.plugin_configuration.get('engine-kv-v1', 'delimiter')
 
         match = re.search("^/(.)/(.*)", path)
         tokens = match.groups() if match else []

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -121,14 +121,13 @@ def make_hc_config(site_parameters):
             username={username}
             password={password}
 
-            {extra_conf}
-
             [approle-authentication]
             role = {role}
             vault_token = {vault_token}
 
             [engine-kv-v1]
             secrets_path = {secrets_path}
+            {extra_conf}
         """.format(
             address=site_parameters['address'],
             port=site_parameters['port'],

--- a/lib/tests/test_client.py
+++ b/lib/tests/test_client.py
@@ -302,13 +302,13 @@ def data_provider():
 
 
 @patch('safeguard.sessions.plugin.requests_tls.RequestsTLS', return_value=REQUESTS_TLS)
-@pytest.mark.parametrize('auth_method, instance, extra_config', data_provider())
-def test_client_uses_the_appropriate_authenticator(_requests_tls, auth_method, instance, extra_config):
+@pytest.mark.parametrize('auth_method, instance, extra_parts', data_provider())
+def test_client_uses_the_appropriate_authenticator(_requests_tls, auth_method, instance, extra_parts):
     SESSION.get.side_effect = GET_RESPONSES
     config = PluginConfiguration(
         hashicorp_vault_config(
             auth_method=auth_method,
-            extra_parts=extra_config) +
+            extra_parts=extra_parts) +
         HASHICORP_VAULT_APPROLE_AUTH_CONFIG +
         HASHICORP_VAULT_KV_V1_CONFIG
     )
@@ -330,15 +330,17 @@ def authenticator_password_cases():
     )
 
 
-@pytest.mark.parametrize('extra_conf, users, expected', authenticator_password_cases())
+@pytest.mark.parametrize('extra_parts, users, expected', authenticator_password_cases())
 @patch('safeguard.sessions.plugin.requests_tls.RequestsTLS', return_value=REQUESTS_TLS)
-def test_authenticator_calculates_username_and_password_according_to_config(_requests_tls, mocker, extra_conf, users, expected):
+def test_authenticator_calculates_username_and_password_according_to_config(
+        _requests_tls, mocker, extra_parts, users, expected
+):
     SESSION.get.side_effect = GET_RESPONSES
     vault_address = 'https://{}:{}'.format(ADDRESS, PORT)
     config = PluginConfiguration(
         hashicorp_vault_config(
             auth_method='ldap',
-            extra_parts=extra_conf) +
+            extra_parts=extra_parts) +
         HASHICORP_VAULT_APPROLE_AUTH_CONFIG +
         HASHICORP_VAULT_KV_V1_CONFIG
     )

--- a/lib/tests/test_plugin.py
+++ b/lib/tests/test_plugin.py
@@ -178,11 +178,10 @@ def provide_secret_cases():
 
         yield pytest.param(
             dedent("""
-                [hashicorp]
-                key_field=my_key_field
-                password_field=my_password_field
                 [engine-kv-v1]
                 secrets_path=kv/users
+                key_field=my_key_field
+                password_field=my_password_field
             """),
             "alice",
             "10.0.0.5",
@@ -194,11 +193,10 @@ def provide_secret_cases():
 
         yield pytest.param(
             dedent("""
-                [hashicorp]
-                key_field=my_key_field
-                password_field=my_password_field
                 [engine-kv-v1]
                 secrets_path=kv/users
+                key_field=my_key_field
+                password_field=my_password_field
             """),
             "alice",
             "10.0.0.5",
@@ -210,12 +208,11 @@ def provide_secret_cases():
 
         yield pytest.param(
             dedent("""
-                [hashicorp]
+                [engine-kv-v1]
+                secrets_path=kv/users
                 key_field=my_key_field
                 password_field=my_password_field
                 delimiter=:
-                [engine-kv-v1]
-                secrets_path=kv/users
             """),
             "alice",
             "10.0.0.5",
@@ -227,12 +224,11 @@ def provide_secret_cases():
 
         yield pytest.param(
             dedent("""
-                [hashicorp]
+                [engine-kv-v1]
+                secrets_path=kv/users
                 key_field=my_key_field
                 password_field=my_password_field
                 delimiter=:
-                [engine-kv-v1]
-                secrets_path=kv/users
             """),
             "alice",
             "10.0.0.5",
@@ -244,12 +240,11 @@ def provide_secret_cases():
 
         yield pytest.param(
             dedent("""
-                [hashicorp]
+                [engine-kv-v1]
+                secrets_path=/kv/users
                 key_field=my_key_field
                 password_field=my_password_field
                 delimiter=:
-                [engine-kv-v1]
-                secrets_path=/kv/users
             """),
             "alice",
             "10.0.0.5",


### PR DESCRIPTION
Move password_field, key_field, delimiter under secret-kv-v1.

Add TLS settings to default.cfg.
Rename extra_config to extra_parts in tests to avoid confusion.

Signed-off-by: Gyorgy Krajcsovits <gyorgy.krajcsovits@oneidentity.com>